### PR TITLE
Use dynamic scoping to change directory when executing a tool

### DIFF
--- a/prosjekt/prosjekt.el
+++ b/prosjekt/prosjekt.el
@@ -470,12 +470,10 @@ BINDINGS is a list of (keycode command)."
 	      (define-key keymap key
 		(lambda ()
 		  (interactive)
-		  (let ((old-dir default-directory))
-		    (when prosjekt-proj-dir (cd prosjekt-proj-dir))
+		  (let* ((default-directory (or prosjekt-proj-dir default-directory)))
 		    (if is-interactive
 			(call-interactively command)
-		      (eval command))
-		    (cd old-dir)))))))))
+		      (eval command))))))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Populate support


### PR DESCRIPTION
For some reason (I'm not sure why!) using `cd` to change directories
does not work consistently. I think this is probably because other
buffers are opened, depending on the tool's command and the wrong buffer
gets the `cd` command applied. This makes it behave more
consistently.
