### PR TITLE
Add Package-Requires header

### DIFF
--- a/prosjekt/ext/anything/anything-prosjekt.el
+++ b/prosjekt/ext/anything/anything-prosjekt.el
@@ -4,6 +4,7 @@
 ;; Author: Austin Bingham <austin.bingham@gmail.com>
 ;; Version: 0.1
 ;; URL: https://github.com/abingham/prosjekt
+;; Package-Requires: ((prosjekt "0.3") (anything "0"))
 
 ;; Originally based on anything-eproject by Daniel Hackney
 ;; http://www.emacswiki.org/emacs/anything-eproject.el

--- a/prosjekt/ext/helm/helm-prosjekt.el
+++ b/prosjekt/ext/helm/helm-prosjekt.el
@@ -4,6 +4,7 @@
 ;; Author: Sohail Somani <sohail@taggedtype.net>
 ;; Version: 0.1
 ;; URL: https://github.com/abingham/prosjekt
+;; Package-Requires: ((prosjekt "0.3") (helm "1.5.9"))
 
 ;; Originally based on anything-prosjekt by Austin Bingham
 


### PR DESCRIPTION
When installed as a package from an ELPA archive such as [MELPA](http://melpa.milkbox.net/), this header tells `package.el` to also install `prosjekt`, `helm` or `anything`, which the library requires. For information about this fix, See [Library-Headers](http://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html).
