### PR TITLE
Eval prosjekt-format-version in prosjekt-default-project

### DIFF
--- a/prosjekt/prosjekt.el
+++ b/prosjekt/prosjekt.el
@@ -481,7 +481,7 @@ and b) matches no pattern in IGNORES"
      '(:includes ".*")
      '(:open-hooks)
      '(:close-hooks)
-     '(:version . prosjekt-format-version)
+     `(:version . ,prosjekt-format-version)
      )))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
This commit fix following error which is occured in `prosjekt-upgrade` when executing `prosjekt-new`:

```
cond: Wrong type argument: number-or-marker-p, prosjekt-format-version
```
