### PR TITLE
Fix anything-c-source-prosjekt-files-init

### DIFF
--- a/prosjekt/ext/anything/anything-prosjekt.el
+++ b/prosjekt/ext/anything/anything-prosjekt.el
@@ -85,7 +85,7 @@
   (with-current-buffer (anything-candidate-buffer 'local)
     (mapcar
      (lambda (item)
-       (insert (format "%s/%s\n" (prosjekt-proj-name) item)))
+       (insert (format "%s\n" item)))
      (prosjekt-proj-files))))
 
 (defvar anything-c-source-prosjekt-projects


### PR DESCRIPTION
This commit fix following error when using anything-c-source-prosjekt-files

```
format: Symbol's function definition is void: prosjekt-proj-name
```
