### PR TITLE
Fix package

### DIFF
--- a/prosjekt/prosjekt.el
+++ b/prosjekt/prosjekt.el
@@ -86,6 +86,7 @@
 
 (require 'thingatpt) ; for read-from-whole-string
 (require 'dash)	     ; for -any?
+(require 'cl)
 
 (defmacro prosjekt-with-cfg (&rest body)
     "Load the global config, bind it to `cfg`, run BODY, and save the global config."

--- a/prosjekt/prosjekt.el
+++ b/prosjekt/prosjekt.el
@@ -112,6 +112,21 @@
 (defconst prosjekt-format-version 3
   "The current format version for projects.")
 
+(defvar prosjekt-proj nil
+  "The current project definition.")
+
+(defvar prosjekt-proj-dir nil
+  "The directory of the current project.")
+
+(defvar prosjekt-private-fields '(:curfile :files :version)
+  "Project fields which are not displayed in the setup buffer.")
+
+(defvar prosjekt-buffer nil
+  "The buffer for prosjekt editing tasks.")
+
+(defvar prosjekt-proj-file nil
+  "The filename of the current project.")
+
 ;;;###autoload
 (defun prosjekt-new (directory name)
   "Create a new project."
@@ -371,12 +386,6 @@ and b) matches no pattern in IGNORES"
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; active-project related stuff.
 
-(defvar prosjekt-proj nil
-  "The current project definition.")
-
-(defvar prosjekt-proj-dir nil
-  "The directory of the current project.")
-
 (defun prosjekt-proj-check ()
   "Check if a project is currently open, throwing an error if not."
   (unless prosjekt-proj 
@@ -506,15 +515,6 @@ and b) matches no pattern in IGNORES"
     
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; active-project related stuff.
-
-(defvar prosjekt-private-fields '(:curfile :files :version)
-  "Project fields which are not displayed in the setup buffer.")
-
-(defvar prosjekt-buffer nil
-  "The buffer for prosjekt editing tasks.")
-
-(defvar prosjekt-proj-file nil
-  "The filename of the current project.")
 
 (defun-autosave prosjekt-setup-save ()
   "Save the prosjekt-buffer contents and the new project definition."


### PR DESCRIPTION
- Change variable declaration positions for byte-compile warning
- Load cl.el for using its macros and functions

This fixes most byte-compile warnings.

```
In prosjekt-delete:
prosjekt.el:157:19:Warning: reference to free variable `prosjekt-proj-file'

In prosjekt-open:
prosjekt.el:184:42:Warning: assignment to free variable `prosjekt-proj-file'
prosjekt.el:190:36:Warning: assignment to free variable `prosjekt-proj-dir'
prosjekt.el:184:11:Warning: reference to free variable `prosjekt-proj-file'
prosjekt.el:182:9:Warning: assignment to free variable `prosjekt-proj'
prosjekt.el:190:11:Warning: reference to free variable `prosjekt-proj-dir'

In prosjekt-clone:
prosjekt.el:236:12:Warning: assignment to free variable `prosjekt-proj-file'
prosjekt.el:237:12:Warning: assignment to free variable `prosjekt-proj-dir'
prosjekt.el:238:12:Warning: assignment to free variable `prosjekt-proj'

In prosjekt-save:
prosjekt.el:252:7:Warning: reference to free variable `prosjekt-proj'
prosjekt.el:255:8:Warning: reference to free variable `prosjekt-proj-file'

In prosjekt-close:
prosjekt.el:271:7:Warning: reference to free variable `prosjekt-proj'
prosjekt.el:275:9:Warning: assignment to free variable `prosjekt-proj'
prosjekt.el:276:9:Warning: assignment to free variable `prosjekt-proj-file'
prosjekt.el:277:9:Warning: assignment to free variable `prosjekt-proj-dir'

In prosjekt-setup:
prosjekt.el:293:11:Warning: reference to free variable `prosjekt-proj'
prosjekt.el:294:25:Warning: reference to free variable `prosjekt-buffer'
prosjekt.el:298:28:Warning: assignment to free variable `prosjekt-buffer'
prosjekt.el:310:13:Warning: reference to free variable
    `prosjekt-private-fields'

In prosjekt-add:
prosjekt.el:321:21:Warning: reference to free variable `prosjekt-proj'

In prosjekt-populate:
prosjekt.el:330:11:Warning: reference to free variable `prosjekt-proj-dir'

In prosjekt-repopulate:
prosjekt.el:349:11:Warning: reference to free variable `prosjekt-proj-dir'

In prosjekt-run-tool-by-name:
prosjekt.el:364:39:Warning: reference to free variable `prosjekt-proj-dir'

In prosjekt-setkeys:
prosjekt.el:594:26:Warning: `(command command)' is a malformed function

In end of data:
prosjekt.el:687:1:Warning: the following functions are not known to be defined: reduce,
    remove*, lexical-let, is-interactive, remove-if-not
```
